### PR TITLE
add C++ to other languages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ let uniques = iter.uniqBy(obj => obj.field);
 
 | language | library | simple API | with comparator | with mapping |
 |----------|---------|------------|-----------------|--------------|
-| C++ | std::algorithm | `unique` | `unique` | -- |
+| C++ | <algorithm> | `unique` | `unique` | -- |
 | Clojure | core | `distinct` | -- | -- |
 | Elm | List.Extra | `unique` | -- | `uniqueBy` |
 | Haskell | Data.List | `nub` | `nubBy` | -- |

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ let uniques = iter.uniqBy(obj => obj.field);
 
 | language | library | simple API | with comparator | with mapping |
 |----------|---------|------------|-----------------|--------------|
-| C++ | <algorithm> | `unique` | `unique` | -- |
+| C++ | &lt;algorithm> | `unique` | `unique` | -- |
 | Clojure | core | `distinct` | -- | -- |
 | Elm | List.Extra | `unique` | -- | `uniqueBy` |
 | Haskell | Data.List | `nub` | `nubBy` | -- |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ let uniques = iter.uniqBy(obj => obj.field);
 
 | language | library | simple API | with comparator | with mapping |
 |----------|---------|------------|-----------------|--------------|
+| C++ | std::algorithm | `unique` | `unique` | -- |
 | Clojure | core | `distinct` | -- | -- |
 | Elm | List.Extra | `unique` | -- | `uniqueBy` |
 | Haskell | Data.List | `nub` | `nubBy` | -- |


### PR DESCRIPTION
[`std::unique`](https://en.cppreference.com/w/cpp/algorithm/unique) does this in C++. It has an overload which takes a binary predicate, for which "[t]he behavior is undefined if it is not an equivalence relation."